### PR TITLE
Implement KCL package level unit tests

### DIFF
--- a/kcl/kcl.go
+++ b/kcl/kcl.go
@@ -3,13 +3,14 @@ package kcl
 import (
 	"bufio"
 	"encoding/json"
+	"io/ioutil"
 	"log"
 	"os"
 
 	"github.com/pkg/errors"
 )
 
-var defaultLogger = log.New(os.Stderr, "", log.LstdFlags)
+var defaultLogger = log.New(ioutil.Discard, "", log.LstdFlags)
 
 type KCLProcess interface {
 	Run() error


### PR DESCRIPTION
In order to make unit testing easier, I created a reader (*bufio.Reader) and writer (*bufio.Writer) as member variables of the kclProcess struct. This allows unit tests to mock the inputs and outputs to the kclProcess.