### PR TITLE
Expose shardID as part of InitializeInput

### DIFF
--- a/kcl/kcl.go
+++ b/kcl/kcl.go
@@ -159,7 +159,7 @@ func (k *kclProcess) Run() error {
 		case "initialize":
 			k.shardID = msg.ShardID
 			k.recordProcessor.Initialize(&InitializationInput{
-				shardID: k.shardID,
+				ShardID: k.shardID,
 			})
 
 		case "processRecords":

--- a/kcl/kcl_test.go
+++ b/kcl/kcl_test.go
@@ -76,8 +76,8 @@ func TestRun_Initialize(t *testing.T) {
 		t.Errorf("expected the kclProcess to write '%s', but instead it wrote '%s'", expectedOutput, output)
 	}
 
-	if mProcessor.initializeCall.shardID != "someShardID" {
-		t.Errorf("unexpected shardID from initialize call %s", mProcessor.initializeCall.shardID)
+	if mProcessor.initializeCall.ShardID != "someShardID" {
+		t.Errorf("unexpected shardID from initialize call %s", mProcessor.initializeCall.ShardID)
 	}
 
 	if mProcessor.shutdownRequestedCall == nil {

--- a/kcl/processor.go
+++ b/kcl/processor.go
@@ -4,7 +4,7 @@ type CheckpointFunc = func(*string) error
 
 type (
 	InitializationInput struct {
-		shardID string
+		ShardID string
 	}
 	ProcessRecordsInput struct {
 		Records    []Record


### PR DESCRIPTION
* This will be useful for consumers to know which shardID they are
  consuming from