### PR TITLE
Fix shutdown and shard end behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,6 @@ run_sample: install_jars build_runner build_sample_app
 	./runner/cmd/runner -jar jar -java `which java` -properties sample/sample.properties
 
 run_integ_test: install_jars build_runner build_integration_processor
-	docker-compose up -d && \
+	docker compose up -d && \
 	go test -count=1 -v ./integration-tests && \
-	docker-compose down
+	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,10 @@
-version: "3.7"
-
 services:
   localstack:
-    image: localstack/localstack
+    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
+    image: localstack/localstack:3.7.2
     ports:
-      - "4566:4566"
+      - "127.0.0.1:4566:4566" # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559" # external services port range
     environment:
-      - HOSTNAME=localstack
-      - HOSTNAME_EXTERNAL=localstack
-      - DEFAULT_REGION=us-east-1
-      - SERVICES=kinesis,dynamodb
-      - DOCKER_HOST=unix:///var/run/docker.sock
-    volumes:
-      - /private/tmp/localstack:/tmp/localstack
-      - /var/run/docker.sock:/var/run/docker.sock
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+      - DEBUG=${DEBUG:-0}

--- a/integration-tests/test-app/test_app_properties.tmpl
+++ b/integration-tests/test-app/test_app_properties.tmpl
@@ -79,7 +79,7 @@ shardSyncIntervalMillis = 5000
 # value is provided a CachedThreadPool is used.
 #maxActiveThreads = 0
 
-ShutdownGraceMillis = 10000
+shutdownGraceMillis = 10000
 
 # These settings are needed in order to work with localstack
 kinesisEndpoint = http://localhost:4566

--- a/kcl/kcl.go
+++ b/kcl/kcl.go
@@ -3,6 +3,7 @@ package kcl
 import (
 	"bufio"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -150,6 +151,14 @@ func (k *kclProcess) readLine() ([]byte, error) {
 func (k *kclProcess) Run() error {
 	for {
 		msg, err := k.readMessage()
+
+		// If this process gets an EOF, it probably means the MultiLangDaemon is
+		// shutting down this worker, so just return nil so that this process
+		// can exit gracefully.
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+
 		if err != nil {
 			return err
 		}

--- a/kcl/kcl.go
+++ b/kcl/kcl.go
@@ -148,7 +148,6 @@ func (k *kclProcess) readLine() ([]byte, error) {
 }
 
 func (k *kclProcess) Run() error {
-	shouldExit := false
 	for {
 		msg, err := k.readMessage()
 		if err != nil {
@@ -175,14 +174,11 @@ func (k *kclProcess) Run() error {
 			k.recordProcessor.ShardEnded(&ShardEndedInput{
 				Checkpoint: k.checkpoint,
 			})
-			shouldExit = true
 
 		case "shutdownRequested":
 			k.recordProcessor.ShutdownRequested(&ShutdownRequestedInput{
-				SequenceNumber: msg.Checkpoint,
-				Checkpoint:     k.checkpoint,
+				Checkpoint: k.checkpoint,
 			})
-			shouldExit = true
 
 		default:
 			return errors.New("unknown message")
@@ -190,10 +186,6 @@ func (k *kclProcess) Run() error {
 
 		if err := k.writeStatus(msg.Action); err != nil {
 			return errors.Wrap(err, "error writing status")
-		}
-
-		if shouldExit {
-			return nil
 		}
 	}
 }

--- a/kcl/processor.go
+++ b/kcl/processor.go
@@ -10,16 +10,12 @@ type (
 		Records    []Record
 		Checkpoint CheckpointFunc `json:"-"`
 	}
-	ShouldCheckpointInput struct {
-		SourceCallType string
-	}
 	LeaseLostInput  struct{}
 	ShardEndedInput struct {
-		Checkpoint CheckpointFunc
+		Checkpoint CheckpointFunc `json:"-"`
 	}
 	ShutdownRequestedInput struct {
-		SequenceNumber string
-		Checkpoint     CheckpointFunc
+		Checkpoint CheckpointFunc `json:"-"`
 	}
 )
 

--- a/sample/generate-sample-data.sh
+++ b/sample/generate-sample-data.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+counter=0
+
+while true; do
+    aws kinesis put-record --region us-east-1 --stream-name sample_kinesis_stream --cli-binary-format raw-in-base64-out --data $RANDOM --partition-key $RANDOM > /dev/null
+    ((counter++))
+    echo "Records put: $counter"
+    sleep 0.5
+done

--- a/sample/main.go
+++ b/sample/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"time"
 
@@ -11,7 +12,8 @@ import (
 
 func main() {
 	now := time.Now()
-	file, err := os.Create(fmt.Sprintf("sample-log-%d", now.Unix()))
+	uuid := rand.Int31()
+	file, err := os.Create(fmt.Sprintf("sample-log-%d-%d", now.Unix(), uuid))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sample/sample.properties
+++ b/sample/sample.properties
@@ -58,7 +58,7 @@ regionName = us-east-1
 # Cleanup leases upon shards completion (don't wait until they expire in Kinesis).
 # Keeping leases takes some tracking/resources (e.g. they need to be renewed, assigned), so by default we try
 # to delete the ones we don't need any longer.
-#cleanupLeasesUponShardCompletion = true
+cleanupLeasesUponShardCompletion = true
 
 # Backoff time in milliseconds for Amazon Kinesis Client Library tasks (in the event of failures).
 #taskBackoffTimeMillis = 500
@@ -79,4 +79,4 @@ regionName = us-east-1
 # value is provided a CachedThreadPool is used.
 #maxActiveThreads = 0
 
-ShutdownGraceMillis = 10000
+shutdownGraceMillis = 10000


### PR DESCRIPTION
The KCL `Run()` event loop should not exit after handling the `ShardEnd` and `ShutdownRequested` events. A better way to exit gracefully is by letting the MutliLangDaemon close STDIN and the Go process can detect that via the EOF.