### PR TITLE
Update default maven URL to https://repo1.maven.org/maven2/

### DIFF
--- a/jar-download/download.go
+++ b/jar-download/download.go
@@ -21,14 +21,14 @@ type downloader struct {
 	packages     []mavenPackage
 }
 
-func getDownloader() *downloader {
+func getDownloader(maxRetries int, mavenBaseURL string) *downloader {
 	return &downloader{
-		maxRetries: 3,
+		maxRetries: maxRetries,
 		backoff:    500 * time.Millisecond,
 		httpClient: &http.Client{},
 
 		packages:     mavenPackages,
-		mavenBaseURL: mavenBaseHTTPURL,
+		mavenBaseURL: mavenBaseURL,
 	}
 }
 

--- a/jar-download/download_test.go
+++ b/jar-download/download_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,7 +15,7 @@ func TestDownload(t *testing.T) {
 	}))
 	defer server.Close()
 
-	d := getDownloader()
+	d := getDownloader(3, server.URL+"/")
 	d.packages = []mavenPackage{
 		{
 			Artifact: "some.artifact.path",
@@ -24,9 +23,8 @@ func TestDownload(t *testing.T) {
 			Version:  "1.2.3",
 		},
 	}
-	d.mavenBaseURL = server.URL + "/?filename="
 
-	tempDir, err := ioutil.TempDir("", "someDir")
+	tempDir, err := os.MkdirTemp("", "someDir")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,12 +38,7 @@ func TestDownload(t *testing.T) {
 
 	// Validate file is saved properly
 	downloadedFile := path.Join(tempDir, "some.artifact.path-1.2.3.jar")
-	file, err := os.Open(downloadedFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data, err := ioutil.ReadAll(file)
+	data, err := os.ReadFile(downloadedFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/jar-download/main.go
+++ b/jar-download/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 )
 
 // Credit to https://github.com/arthurbailao/aws-kcl/blob/master/cmd/aws-kcl/download.go
@@ -16,10 +17,28 @@ func main() {
 		dstFolder = os.Args[1]
 	}
 
-	d := getDownloader()
+	mavenBaseURL := "https://repo1.maven.org/maven2/"
+	if os.Getenv("MAVEN_BASE_URL") != "" {
+		mavenBaseURL = os.Getenv("MAVEN_BASE_URL")
+	}
+	fmt.Printf("Using Maven base URL: %s\n", mavenBaseURL)
+
+	maxRetries := 3
+	if os.Getenv("MAX_MAVEN_HTTP_RETRIES") != "" {
+		var err error
+		maxRetries, err = strconv.Atoi(os.Getenv("MAX_MAVEN_HTTP_RETRIES"))
+		if err != nil {
+			fmt.Printf("failed to parse MAX_MAVEN_HTTP_RETRIES: %+v\n", err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("Using max Maven HTTP retries: %d\n", maxRetries)
+
+	d := getDownloader(maxRetries, mavenBaseURL)
 	err := d.download(dstFolder)
 	if err != nil {
 		fmt.Printf("failed to download due to error: %+v\n", err)
+		os.Exit(1)
 	}
 
 	fmt.Println("Completed download")

--- a/jar-download/maven.go
+++ b/jar-download/maven.go
@@ -21,8 +21,6 @@ func (pkg *mavenPackage) Name() string {
 	return fmt.Sprintf("%s-%s.jar", pkg.Artifact, pkg.Version)
 }
 
-const mavenBaseHTTPURL = "https://search.maven.org/remotecontent?filepath="
-
 // To update the packages to newer versions follow instructions here:
 // https://github.com/awslabs/amazon-kinesis-client-python/blob/master/scripts/build_deps.py
 // TODO: Be careful when updating the aws java sdk dependencies:


### PR DESCRIPTION
I noticed 403 and 501 errors from `search.maven.org`. It looks like that subdomain is slowly being deprecated https://central.sonatype.org/faq/what-happened-to-search-maven-org/#what-happened-to-searchmavenorg_1.

https://repo1.maven.org/maven2/ is a good repository to use per https://central.sonatype.org/consume/.

The AWS python KCL has made similar changes as well
https://github.com/awslabs/amazon-kinesis-client-python/pull/283/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7